### PR TITLE
Fixes check for FF_LBA64

### DIFF
--- a/source/ff.h
+++ b/source/ff.h
@@ -118,7 +118,7 @@ typedef QWORD LBA_t;
 typedef DWORD LBA_t;
 #endif
 #else
-#if FF_LBA64
+#if FF_LBA64 == 1
 #error exFAT needs to be enabled when enable 64-bit LBA
 #endif
 typedef DWORD FSIZE_t;


### PR DESCRIPTION
- When FF_LBA64 is 0 this check is not valid because it's only checking if it's defined, not the value.