### PR TITLE
1. March 5, 2022

### DIFF
--- a/source/ff.c
+++ b/source/ff.c
@@ -5957,7 +5957,7 @@ FRESULT f_mkfs (
 		sz_fat = (DWORD)((sz_vol / sz_au + 2) * 4 + ss - 1) / ss;	/* Number of FAT sectors */
 		b_data = (b_fat + sz_fat + sz_blk - 1) & ~((LBA_t)sz_blk - 1);	/* Align data area to the erase block boundary */
 		if (b_data - b_vol >= sz_vol / 2) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Too small volume? */
-		n_clst = (DWORD)(sz_vol - (b_data - b_vol)) / sz_au;	/* Number of clusters */
+		n_clst = (DWORD)((sz_vol - (b_data - b_vol)) / sz_au);	/* Number of clusters */
 		if (n_clst <16) LEAVE_MKFS(FR_MKFS_ABORTED);			/* Too few clusters? */
 		if (n_clst > MAX_EXFAT) LEAVE_MKFS(FR_MKFS_ABORTED);	/* Too many clusters? */
 
@@ -6524,7 +6524,7 @@ static void putc_bfd (putbuff* pb, TCHAR c)
 			if ((BYTE)c < 0x80) break;					/* Single byte? */
 			if (((BYTE)c & 0xE0) == 0xC0) pb->ct = 1;	/* 2-byte sequence? */
 			if (((BYTE)c & 0xF0) == 0xE0) pb->ct = 2;	/* 3-byte sequence? */
-			if (((BYTE)c & 0xF1) == 0xF0) pb->ct = 3;	/* 4-byte sequence? */
+			if (((BYTE)c & 0xF8) == 0xF0) pb->ct = 3;	/* 4-byte sequence? */
 			return;
 		} else {				/* In the multi-byte sequence */
 			if (((BYTE)c & 0xC0) != 0x80) {	/* Broken sequence? */


### PR DESCRIPTION
--------------------------------------------------------------------------------------------------
f_mkfs function creates broken exFAT volume when the size of volume is >= 2^32 sectors (2 TiB in 512 bytes/sector).

2. April 4, 2022
--------------------------------------------------------------------------------------------------
String functions, f_puts and f_printf, cannot write the unicode characters not in BMP to the file when FF_LFN_UNICODE == 2 (UTF-8).