### PR TITLE
fix: fix maybe-uninitialized warning

### DIFF
--- a/source/ff.c
+++ b/source/ff.c
@@ -4828,6 +4828,7 @@ FRESULT f_getfree (
 	UINT i;
 	FFOBJID obj;
 
+	memset(&obj, 0, sizeof (obj));
 
 	/* Get logical drive */
 	res = mount_volume(&path, &fs, 0);


### PR DESCRIPTION
When `FF_FS_EXFAT` is enabled, the function `f_getfree` calls the function `get_fat` and passes the local variable `obj` to `get_fat`.

The `FS_EXFAT` branch will access variables such as uninitialized `obj->objsize`, which may cause errors. 

The solution is to completely initialize `obj` to 0 to avoid unknown errors.

![image](https://github.com/abbrev/fatfs/assets/26767803/57f5bf38-bbe9-4d31-8ead-1357532ead7a)
![image](https://github.com/abbrev/fatfs/assets/26767803/e5218134-d6a9-4481-af3d-1f4a8a12aa99)

```bash
ff.c: In function 'f_getfree':
ff.c:1170:48: warning: 'obj.objsize' may be used uninitialized in this function [-Wmaybe-uninitialized]
     DWORD clen = (DWORD)((LBA_t)((obj->objsize - 1) / SS(fs)) / fs->csize); /* Number of clusters - 1 */
                                  ~~~~~~~~~~~~~~^~~~
ff.c:4761:10: note: 'obj.objsize' was declared here
  FFOBJID obj;
          ^~~
ff.c:1168:27: warning: 'obj.sclust' may be used uninitialized in this function [-Wmaybe-uninitialized]
    if ((obj->objsize != 0 && obj->sclust != 0) || obj->stat == 0) { /* Object except root dir must have valid data length */
        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
ff.c:4761:10: note: 'obj.sclust' was declared here
  FFOBJID obj;
          ^~~
ff.c:1172:8: warning: 'obj.stat' may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (obj->stat == 2 && cofs <= clen) { /* Is it a contiguous chain? */
        ^
ff.c:4761:10: note: 'obj.stat' was declared here
  FFOBJID obj;
          ^~~
ff.c:1176:24: warning: 'obj.n_cont' may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (obj->stat == 3 && cofs < obj->n_cont) { /* Is it in the 1st fragment? */
         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
ff.c:4761:10: note: 'obj.n_cont' was declared here
  FFOBJID obj;
          ^~~
ff.c:1181:9: warning: 'obj.n_frag' may be used uninitialized in this function [-Wmaybe-uninitialized]
      if (obj->n_frag != 0) { /* Is it on the growing edge? */
         ^
ff.c:4761:10: note: 'obj.n_frag' was declared here
  FFOBJID obj;
          ^~~
```